### PR TITLE
Constrain GPT argument mode to scenario facts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1182,7 +1182,7 @@ function model(){if(!cur)return;const r=$('objResult');r.hidden=false;$('objRuli
    return;
   }
  const role=$('objGPTRole').value||'chatgpt';
- const systemMsg={role:'system',content:`${STATES[CURRENT_STATE].judgePrompt} Use the ${STATES[CURRENT_STATE].name} State and Regional Tournament judges rubric. Act as opposing counsel in a mock trial objection argument. Base all reasoning strictly on the provided transcript and rules. Keep responses concise and in transcript style. Include realistic examples an average mock trial competitor would face.`};
+ const systemMsg={role:'system',content:`${STATES[CURRENT_STATE].judgePrompt} Use the ${STATES[CURRENT_STATE].name} State and Regional Tournament judges rubric. Act as opposing counsel in a mock trial objection argument. Base all reasoning strictly on the provided transcript and rules. Use only facts explicitly stated in the scenario and do not rely on the scenario's artificiality or missing foundation. Keep responses concise and in transcript style. Include realistic examples an average mock trial competitor would face.`};
  let userMsg;
  if(role==='chatgpt'){
   userMsg={role:'user',content:`Transcript:\nFact: ${cur.fact}\nQuestion: ${cur.q}\nCorrect objection: ${cur.ans} (Rule ${cur.rule}).\nExplain the scenario and state the objection from the objecting counsel's perspective. Include realistic examples an average mock trial competitor would face. Do not simulate any response from opposing counsel or the judge. End by inviting my reply and wait for my response.`};
@@ -1318,7 +1318,8 @@ function gptStopRecord(){
     alert('Provide your argument before requesting a ruling.');
     return;
    }
-  const transcript=userMsgs.map(m=>m.content).join('\n');
+  const conversation=gptChat.map(m=>`${m.role==='user'?'User':'Opposing Counsel'}: ${m.content}`).join('\n');
+  const transcript=`The transcript includes both User and Opposing Counsel messages. Evaluate and assign a numerical score only for the User arguments; ignore Opposing Counsel lines.\n\n${conversation}`;
   const prompt=ChatGPTScoring.buildScoringPrompt(transcript,true, ARGUMENT_RUBRIC);
    try{
     const resp=await fetch('https://api.openai.com/v1/chat/completions',{


### PR DESCRIPTION
## Summary
- Limit system prompt so opposing-counsel mode uses only scenario facts and avoids relying on artificial gaps.
- Feed the full conversation transcript to scoring while instructing evaluation of only the user's arguments.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22dc6ac78833188e0992848a83cc7